### PR TITLE
Add AWS AppRunner deployment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,70 @@
+name: CICD
+# List of Github events triggering the workflow
+on: [push, pull_request]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: endsWith( github.ref, '/master' ) || endsWith( github.ref, '/staging' )    
+    steps:      
+      - name: Slack Notification
+        if: endsWith( github.ref, '/master' )
+        uses: lazy-actions/slatify@v3.0.0
+        with:
+          type: ${{ job.status }}
+          job_name: "*Barcodez Deployment Started* > "
+          url: ${{ secrets.SLACK_WEBHOOK }}
+          commit: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Configure AWS credentials
+        id: aws-credentials
+        uses: aws-actions/configure-aws-credentials@v2.2.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1        
+      - name: Set environment variables
+        run: |
+          echo "APP_ENVIRONMENT=$(if [[ "${GITHUB_REF##*/}" == "master" ]]; then echo "production"; \
+                                elif [[ "${GITHUB_REF##*/}" == "staging" ]]; then echo "staging"; fi)" >> $GITHUB_ENV
+          echo "DATE_TIMESTAMP=$(echo $(date +"%Y-%m-%dT%H%M%SZ"))" >> $GITHUB_ENV
+      # Use preceeding variables
+      - name: Set version tag
+        run: echo "IMAGE_TAG=${{ env.APP_ENVIRONMENT }}-${{ env.DATE_TIMESTAMP }}" >> $GITHUB_ENV
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: barcodez
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        run: |
+          docker build --build-arg GO_ENV=$APP_ENVIRONMENT -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"  
+      - name: Deploy to App Runner
+        id: deploy-apprunner
+        uses: awslabs/amazon-app-runner-deploy@v2.5.0
+        with:
+          service: barcodez-${{ env.APP_ENVIRONMENT }}
+          image: ${{ steps.build-image.outputs.image }}
+          access-role-arn: ${{ vars.ROLE_ARN }}
+          region: us-east-1
+          port: ${{ vars.SERVICE_DEFAULT_PORT }}
+          cpu: ${{ vars.SERVICE_DEFAULT_CPU }}
+          memory: ${{ vars.SERVICE_DEFAULT_MEMORY }}
+          # Control service stability timeout
+          wait-for-service-stability-seconds: 1200
+      - name: Slack Notification
+        uses: lazy-actions/slatify@v3.0.0
+        if: endsWith( github.ref, '/master' )
+        with:
+          type: ${{ job.status }}
+          job_name: "*Barcodez Deployment Completed* > "
+          url: ${{ secrets.SLACK_WEBHOOK }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Using lightweight alpine image
 FROM python:3.7-alpine
 
+EXPOSE 8000
+
 # install pipenv and create an app user
 RUN apk update \
       && apk add --no-cache git openssh-client \
@@ -54,7 +56,7 @@ COPY . .
 
 # the "--wsgi-disable-file-wrapper" option is to allow io.BytesIO objects
 # to be served by uwsgi (https://github.com/unbit/uwsgi/issues/1126)
-CMD ["pipenv", "run", "uwsgi", "--wsgi-disable-file-wrapper", "-c", "uwsgi.ini"]
+CMD ["pipenv", "run", "uwsgi", "--wsgi-disable-file-wrapper", "uwsgi.ini"]
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ Or in the Docker container, with:
 
     docker run -p 8000:8000 barcodez
 
+## Deployment
 
+The application container is hosted on AWS [App Runner](https://aws.amazon.com/apprunner/). Internally a service is run on the AWS ECS/FARGATE container infrastructure. 
+App Runner adds an application load balancer as the entrypoint to access a service. 
 
+In order to deploy a new application version, following steps are actioned:
+- Build Docker image
+- Tag and push Docker image to ECR
+- Invoke an App Runner service update with new image version
 
-
+Run `./deploy.sh` locally and select your deployment environment, or push to remote staging for invoking a deployment on Github Actions. 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+
+read -p "Barcodez environment to deploy to? [production/staging]: " APP_ENVIRONMENT
+
+# make sure envsubst can read the var
+export APP_ENVIRONMENT=$APP_ENVIRONMENT
+export DATE_TIMESTAMP=$(echo $(date +"%Y-%m-%dT%H%M%SZ"))
+export IMAGE_TAG=$APP_ENVIRONMENT-$DATE_TIMESTAMP
+
+echo "
+----------------
+ENVIRONMENT > $APP_ENVIRONMENT
+----------------
+"
+
+if [[ "$APP_ENVIRONMENT" == "production" || "$APP_ENVIRONMENT" == "staging" ]]; then
+
+    echo "Building and publishing Docker image"
+
+    # build Docker image with tag matching the current environment and date timestamp
+    docker build --build-arg GO_ENV=$APP_ENVIRONMENT -t barcodez:$IMAGE_TAG .
+    # create matching remote Docker image tags
+    docker tag barcodez:$IMAGE_TAG 947453556251.dkr.ecr.us-east-1.amazonaws.com/barcodez:$IMAGE_TAG
+    # authenticate to Amazon ECR registry with Docker
+    aws --region us-east-1 ecr get-login-password | docker login --username AWS --password-stdin 947453556251.dkr.ecr.us-east-1.amazonaws.com/barcodez
+    # push docker images to remote repository
+    docker push 947453556251.dkr.ecr.us-east-1.amazonaws.com/barcodez:$IMAGE_TAG
+
+    APP_RUNNER_SERVICE=$(aws apprunner list-services --query 'ServiceSummaryList[?ServiceName==`barcodez-'$APP_ENVIRONMENT'`].ServiceArn' --output text)
+
+    echo "Start App Runner Service update"
+    APP_RUNNER_OPERATION_ID=$(aws apprunner update-service --service-arn "$APP_RUNNER_SERVICE" \
+        --source-configuration '{"ImageRepository": {"ImageIdentifier": "947453556251.dkr.ecr.us-east-1.amazonaws.com/barcodez:'$IMAGE_TAG'", "ImageRepositoryType": "ECR"}}' --query 'OperationId')
+
+    aws apprunner list-operations --service-arn $APP_RUNNER_SERVICE --query 'OperationSummaryList[?Id==`'$APP_RUNNER_OPERATION_ID'`]'
+    
+    echo "Invoked app deployment of version $IMAGE_TAG to Barcodez $APP_ENVIRONMENT"
+else
+	echo "Invalid app environment"
+fi

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,8 +1,7 @@
 [uwsgi]
 master = 1
 vacuum = true
-socket = 0.0.0.0:8000
-protocol = http
+http-socket = :8000
 enable-threads = true
 thunder-lock = true
 threads = 8


### PR DESCRIPTION
Add deployment to AWS AppRunner for separate staging and production environments.
App should return identical barcode images than the currently running barcode-server app.

Although not in use, Talkbox can be pointed to a different barcode server via `QR_CODE_SERVER_URL`
At present it defaults to https://barcodes.impactapp.com.au/ for all environments. 

